### PR TITLE
config: fix server->bind when more than 1 char

### DIFF
--- a/meshview/web.py
+++ b/meshview/web.py
@@ -1410,7 +1410,7 @@ async def run_server():
         ssl_context.load_cert_chain(CONFIG["server"]["tls_cert"])
     else:
         ssl_context = None
-    for host in CONFIG["server"]["bind"]:
+    if host := CONFIG["server"]["bind"]:
         site = web.TCPSite(runner, host, CONFIG["server"]["port"], ssl_context=ssl_context)
         await site.start()
     while True:


### PR DESCRIPTION
Currently the bind option in the configuration file defaults to '*' and is read during startup in web.py. The value of the host variable  is of type string, but the current code tries to iterate through it, suppusedly to support multiple hosts.
This would work if the value was of type array, holding multiple strings of hostnames (similar to [mqtt]->topics, which is currently not possible.

When setting 'bind=localhost', the code iterates through 'localhost' and tries to start a TCPSite with a host of 'l', then 'o', then 'c' and so on but failes at the first 'l' already since it cannot be resolved.

This commit changes the behaviour of 'bind' to only expect one value, namely a string of the host where to bind to.

This change does not require any config changes in current productions setups: The default bind value of '*' is still handled correctly and any other bind values with more than one character currently fail anyways.