### PR TITLE
add net_tag to sample.config.ini

### DIFF
--- a/sample.config.ini
+++ b/sample.config.ini
@@ -31,6 +31,7 @@ map_bottom_right_lon=-121
 
 # Note about how your weekly mesh runs. time and tag used for the system to track.
 weekly_net_message= Weekly Mesh check-in. We will keep it open on every Wednesday from 5:00pm for checkins. The message format should be (LONG NAME) - (CITY YOU ARE IN) #BayMeshNet.
+net_tag=#BayMeshNet
 
 # MQTT Server configuration
 [mqtt]


### PR DESCRIPTION
Not having set net_tag in the config file causes a KeyError when opening Weekly Net as the net_tag configuration is expected. Thus setting a default value.