### PR TITLE
Run with docker / docker-compose

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,11 @@
+# Absolute path to the local meshview config.ini
+CONFIG_PATH=./config.ini
+
+# Path to the local meshview db file
+DB_PATH=./packets.db
+
+# Host port to bind the web server to
+HOST_WEB_PORT=8081
+
+# Timezone
+TZ=America/Los_Angeles

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,5 +24,8 @@ RUN cp /app/sample.config.ini /app/config.ini
 # Expose port
 EXPOSE 8081
 
+# Config file should be mounted at /etc/meshview/config.ini
+VOLUME ["/etc/meshview"]
+
 # Run the app via venv
-CMD ["/app/env/bin/python", "/app/mvrun.py"]
+CMD ["/app/env/bin/python", "/app/mvrun.py", "--config", "/etc/meshview/config.ini"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,13 +19,24 @@ docker build -t meshview-docker .
 
 ## Run Instructions
 
+Copy the example configuration and modify:
+
+```bash
+# Copy the sample from this repository
+cp sample.config.ini config.ini
+# Modify with your text editor of choice
+nano config.ini
+```
+
 Run the container:
 
 ```bash
-docker run -d --name meshview-docker -p 8081:8081 meshview-docker
+docker run -d --name meshview-docker -v ./config.ini:/etc/meshview/config.ini -p 8081:8081 meshview-docker
 ```
 
-This maps container port `8081` to your host. The application runs via:
+This maps container port `8081` to your host, and uses the locally stored configuration you modified in the previous step.
+
+The application runs via:
 
 ```bash
 /app/env/bin/python /app/mvrun.py
@@ -42,3 +53,25 @@ If running on a remote server, replace `localhost` with the host's IP or domain 
 http://<host>:8081
 
 Ensure that port `8081` is open and not blocked by a firewall or security group.
+
+## Run with docker-compose
+
+Copy `.env.example` to `.env`:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` to point to your local `config.ini` and `packets.db` files.
+
+Create `packets.db` file if it does not exist, before passing to the container.
+```bash
+touch ./packets.db
+```
+### Start compose
+
+From the location where `meshview` was cloned.
+Start compose in the background:
+```bash
+docker compose up -d
+```

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,23 @@
+# Copy .env.example to .env and set the environment variables
+
+services:
+  meshview:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: meshview
+
+    environment:
+      # Set the timezone, default to America/Los_Angeles
+      - TZ=${TZ:-America/Los_Angeles}
+
+    # Mount local files for data persistence
+    volumes:
+      - "${CONFIG_PATH:-./config.ini}:/etc/meshview/config.ini:ro"
+      - "${DB_PATH:-./packets.db}:/app/packets.db:rw"
+
+    # Forward the container’s port (default 8081) to the host
+    ports:
+      - ${HOST_WEB_PORT:-8081}:8081
+
+    restart: unless-stopped


### PR DESCRIPTION
Run the project with docker-compose, with config that's *hopefully* easy to follow.

Also updated README.

Supercedes #24 