### PR TITLE
Add direction arrow heads to main map edges shown on node click

### DIFF
--- a/meshview/templates/map.html
+++ b/meshview/templates/map.html
@@ -47,6 +47,11 @@
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
         crossorigin=""></script>
 
+<!-- Leaflet PolylineDecorator for arrowheads -->
+<script src="https://unpkg.com/leaflet-polylinedecorator@1.6.0/dist/leaflet.polylinedecorator.js" 
+        integrity="sha384-FhPn/2P/fJGhQLeNWDn9B/2Gml2bPOrKJwFqJXgR3xOPYxWg5mYQ5XZdhUSugZT0"
+        crossorigin=""></script>
+
 <script>
     // ---- Map Setup ----
     var map = L.map('map');
@@ -240,16 +245,25 @@
                 if (!fromNode || !toNode) return;
                 if (isInvalidCoord(fromNode) || isInvalidCoord(toNode)) return;
 
-                const lineColor = edge.type === "neighbor" ? "red" : "blue";
+                const lineColor = edge.type === "neighbor" ? "darkred" : "deepskyblue"; //different than the node category colors
                 const dash = edge.type === "traceroute" ? "5,5" : null;
                 const weight = edge.type === "neighbor" ? 3 : 2;
 
-                L.polyline(
+                const polyline = L.polyline(
                     [[fromNode.lat, fromNode.long], [toNode.lat, toNode.long]],
                     { color: lineColor, weight, opacity: 1, dashArray: dash }
                 )
                 .addTo(edgeLayer)
                 .bringToFront();
+
+                // Add arrowhead
+                if (edge.type === "traceroute") {
+                    L.polylineDecorator(polyline, {
+                        patterns: [
+                            { offset: '100%', repeat: 0, symbol: L.Symbol.arrowHead({ pixelSize: 12, polygon: false, pathOptions: { stroke: true, color: lineColor } }) }
+                        ]
+                    }).addTo(edgeLayer);
+                }
 
                 console.log(`Edge type: To: ${toNode.long_name} (${toNode.lat},${toNode.long})`);
             });


### PR DESCRIPTION
This PR adds an arrow head to each traceroute edge in the main map display.

On the main map view, when a node is clicked, lines appear that indicate traceroute partners. These connections are directional. (a,b) and (b,a) indicate different relationships; the first node is the sender and the second is the receiver in a route. When looking at this display, knowing the sender adds valuable information.

This PR makes three changes:

1. Adds the leaflet-polylinedecorator library to handle the arrow heads.
2. Add an arrow head to the end of each edge displayed. This is only for traceroute data as I am unsure if there is directionality to the neighbors data.
3. Changes the colors of the lines slightly so that the lines stand out against the colors of the node dots. 

I have run this on my laptop for a few days without any noticeable issues.

I tried to solicit feedback on this change from Bayme.sh discord, but there wasn't much to be had. If you have any thoughts on this, please let me know.
Jim

