### PR TITLE
BUG: Fix for api/edges traceback

### DIFF
--- a/meshview/web.py
+++ b/meshview/web.py
@@ -1691,6 +1691,14 @@ async def api_edges(request):
                     f"Error decoding NeighborInfo packet {getattr(packet, 'id', '?')}: {e}"
                 )
 
+    # Convert edges dict to list format for JSON response
+    edges_list = [
+        {"from": frm, "to": to, "type": edge_type}
+        for (frm, to), edge_type in edges.items()
+    ]
+
+    return web.json_response({"edges": edges_list})
+
 
 @routes.get("/api/lang")
 async def api_lang(request):

--- a/meshview/web.py
+++ b/meshview/web.py
@@ -1693,8 +1693,7 @@ async def api_edges(request):
 
     # Convert edges dict to list format for JSON response
     edges_list = [
-        {"from": frm, "to": to, "type": edge_type}
-        for (frm, to), edge_type in edges.items()
+        {"from": frm, "to": to, "type": edge_type} for (frm, to), edge_type in edges.items()
     ]
 
     return web.json_response({"edges": edges_list})


### PR DESCRIPTION
Fixes these errors:

```
2025-10-07 13:43:19 web_protocol.py:481 [pid:15158] ERROR - Missing return statement on request handler
Traceback (most recent call last):
  File "/Users/jkrauska/src-mesh/meshview/env/lib/python3.13/site-packages/aiohttp/web_protocol.py", line 698, in finish_response
    prepare_meth = resp.prepare
                   ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'prepare'
```

This is  fixed by adding a missing return statement to the /api/edges route handler in meshview/web.py
