### PR TITLE
Fix node graph showing all traceroutes in database

### DIFF
--- a/meshview/web.py
+++ b/meshview/web.py
@@ -1209,7 +1209,7 @@ async def nodegraph(request):
         lambda: {"weight": 0, "type": None}
     )  # weight is based on the number of traceroutes and neighbor info packets
     used_nodes = set()  # This will track nodes involved in edges (including traceroutes)
-    since = datetime.timedelta(hours=48)
+    since = datetime.datetime.now() - timedelta(hours=48)
     traceroutes = []
 
     # Fetch traceroutes


### PR DESCRIPTION
This line was missed in a recent update that changed `get_traceroutes` to accept a datetime instead of a timedelta, causing every traceroute in the database to be returned