### PR TITLE
render traceroutes on top

### DIFF
--- a/meshview/web.py
+++ b/meshview/web.py
@@ -431,8 +431,6 @@ async def packet_details_firehose(request):
     )
 
 
-
-
 @routes.get("/packet/{packet_id}")
 async def packet(request):
     try:
@@ -1126,11 +1124,7 @@ async def net(request):
 @routes.get("/map")
 async def map(request):
     template = env.get_template("map.html")
-    return web.Response(
-        text=template.render(),
-        content_type="text/html"
-    )
-
+    return web.Response(text=template.render(), content_type="text/html")
 
 
 @routes.get("/stats")
@@ -1332,6 +1326,7 @@ async def nodegraph(request):
         content_type="text/html",
     )
 
+
 # API Section
 #######################################################################
 # How this works
@@ -1487,7 +1482,6 @@ async def api_nodes(request):
         return web.json_response({"error": "Failed to fetch nodes"}, status=500)
 
 
-
 @routes.get("/api/packets")
 async def api_packets(request):
     try:
@@ -1511,14 +1505,16 @@ async def api_packets(request):
         for p in packets:
             payload = (p.payload or "").strip()
 
-            packets_json.append({
-                "id": p.id,
-                "from_node_id": p.from_node_id,
-                "to_node_id": p.to_node_id,
-                "portnum": int(p.portnum) if p.portnum is not None else None,
-                "import_time": p.import_time.isoformat(),
-                "payload": payload,
-            })
+            packets_json.append(
+                {
+                    "id": p.id,
+                    "from_node_id": p.from_node_id,
+                    "to_node_id": p.to_node_id,
+                    "portnum": int(p.portnum) if p.portnum is not None else None,
+                    "import_time": p.import_time.isoformat(),
+                    "payload": payload,
+                }
+            )
 
         return web.json_response({"packets": packets_json})
 
@@ -1622,6 +1618,7 @@ async def api_edges(request):
 
     return web.json_response({"edges": edges_list})
 
+
 @routes.get("/api/config")
 async def api_config(request):
     try:
@@ -1678,7 +1675,9 @@ async def api_config(request):
             "map_bottom_right_lon": get_float(site, "map_bottom_right_lon", -121.0),
             "map_interval": get_int(site, "map_interval", 3),
             "firehose_interval": get_int(site, "firehose_interval", 3),
-            "weekly_net_message": get_str(site, "weekly_net_message", "Weekly Mesh check-in message."),
+            "weekly_net_message": get_str(
+                site, "weekly_net_message", "Weekly Mesh check-in message."
+            ),
             "net_tag": get_str(site, "net_tag", "#BayMeshNet"),
             "version": str(SOFTWARE_RELEASE),
         }
@@ -1687,6 +1686,7 @@ async def api_config(request):
         mqtt = CONFIG.get("mqtt", {})
         topics_raw = get(mqtt, "topics", [])
         import json
+
         if isinstance(topics_raw, str):
             try:
                 topics = json.loads(topics_raw)


### PR DESCRIPTION
this change /should/ render traceroute blue lines on top of grey lines.

In the traceroute graph, the edges (lines) are rendered with colors based on the path hash, but they all have the same rendering order. When blue lines are drawn first and grey lines are drawn later, the grey lines will appear on top and cover the blue lines.

  The fix is to ensure that lines with more important colors (like blue, which likely represents the complete/successful path) are drawn last so they appear on top. Looking at
   the code:

  1. In web.py:862, all paths get the same color calculation based on their hash
  2. In traceroute.html:63-71, all edges are mapped with the same z-index/rendering order

  The solution is to add a z-index or reorder the edges so that the complete paths (those with tr.done == True) are rendered last.