### PR TITLE
Add relay_node field to PacketSeen model and update template for display

### DIFF
--- a/add_relay_node_column.py
+++ b/add_relay_node_column.py
@@ -1,0 +1,20 @@
+"""
+Migration script to add relay_node column to packet_seen table.
+Run this once to update your database schema.
+"""
+import asyncio
+from meshview import database
+
+async def add_relay_node_column():
+    """Add relay_node column to packet_seen table"""
+    async with database.async_session() as session:
+        # Add the column
+        await session.execute("""
+            ALTER TABLE packet_seen 
+            ADD COLUMN IF NOT EXISTS relay_node BIGINT
+        """)
+        await session.commit()
+        print("Successfully added relay_node column to packet_seen table")
+
+if __name__ == "__main__":
+    asyncio.run(add_relay_node_column())

--- a/meshview/models.py
+++ b/meshview/models.py
@@ -73,6 +73,7 @@ class PacketSeen(Base):
     rx_time: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     hop_limit: Mapped[int] = mapped_column(nullable=True)
     hop_start: Mapped[int] = mapped_column(nullable=True)
+    relay_node: Mapped[int] = mapped_column(BigInteger, nullable=True)
     channel: Mapped[str] = mapped_column(nullable=True)
     rx_snr: Mapped[float] = mapped_column(nullable=True)
     rx_rssi: Mapped[int] = mapped_column(nullable=True)

--- a/meshview/mqtt_store.py
+++ b/meshview/mqtt_store.py
@@ -121,6 +121,7 @@ async def process_envelope(topic, env):
                 rx_rssi=env.packet.rx_rssi,
                 hop_limit=env.packet.hop_limit,
                 hop_start=env.packet.hop_start,
+                relay_node=env.packet.relay_node if env.packet.relay_node else None,
                 topic=topic,
                 import_time=datetime.datetime.now(),
             )

--- a/meshview/templates/packet_details.html
+++ b/meshview/templates/packet_details.html
@@ -20,6 +20,8 @@
                 <dd>{{seen.hop_limit}}</dd>
                 <dt>hop_start</dt>
                 <dd>{{seen.hop_start}}</dd>
+                <dt>relay_node</dt>
+                <dd>{{seen.relay_node|node_id_to_hex if seen.relay_node else 'N/A'}}</dd>
                 <dt>channel</dt>
                 <dd>{{seen.channel}}</dd>
                 <dt>rx_snr</dt>


### PR DESCRIPTION
This pull request adds support for tracking and displaying the `relay_node` attribute for packets seen in the mesh network. The changes ensure that the relay node information is stored in the database, processed from incoming packets, and shown in the packet details UI.

**Database and data model enhancements:**

* Added a new `relay_node` field to the `PacketSeen` model to store the relay node ID for each packet.

**Data ingestion and processing:**

* Updated the `process_envelope` function to extract and store the `relay_node` value from incoming packets when available.

**User interface improvements:**

* Modified the `packet_details.html` template to display the `relay_node` value (converted to hex if present, otherwise showing 'N/A') in the packet details view.