### PR TITLE
Default channel configuration for Nodegraph and Top pages

### DIFF
--- a/meshview/templates/nodegraph.html
+++ b/meshview/templates/nodegraph.html
@@ -204,16 +204,24 @@ const edges = [
 
 let filteredNodes = [];
 let filteredEdges = [];
-let selectedChannel = 'LongFast';
+// Default channel comes from site configuration; fallback to LongFast
+const defaultChannel = "{{ site_config.get('site', {}).get('default_channel', 'LongFast') }}";
+let selectedChannel = defaultChannel;
 let lastSelectedNode = null;
 
 function populateChannelDropdown() {
     const sel = document.getElementById('channel-select');
+    // Use server-provided channels if available, otherwise derive from node list
+{% if channels is defined %}
+    const serverChannels = {{ channels | tojson | safe }};
+    const unique = serverChannels && serverChannels.length ? serverChannels : [...new Set(nodes.map(n=>n.channel).filter(Boolean))].sort();
+{% else %}
     const unique = [...new Set(nodes.map(n=>n.channel).filter(Boolean))].sort();
+{% endif %}
     unique.forEach(ch=>{
         const opt = document.createElement('option');
         opt.value=ch; opt.text=ch;
-        if(ch==='LongFast') opt.selected=true;
+        if(ch===defaultChannel) opt.selected=true;
         sel.appendChild(opt);
     });
     selectedChannel = sel.value;

--- a/meshview/templates/top.html
+++ b/meshview/templates/top.html
@@ -157,16 +157,19 @@ const stdEl = document.getElementById('stdDev');
 const channelSet = new Set();
 nodes.forEach(n => channelSet.add(n.channel));
 const dropdown = document.getElementById('channelFilter');
+// default channel from site config (fallback to LongFast)
+const defaultChannel = "{{ site_config.get('site', {}).get('default_channel', 'LongFast') }}";
+
 [...channelSet].sort().forEach(channel => {
     const option = document.createElement('option');
     option.value = channel;
     option.textContent = channel;
-    if (channel === "LongFast") option.selected = true;
+    if (channel === defaultChannel) option.selected = true;
     dropdown.appendChild(option);
 });
 
 // Filter default
-filteredNodes = nodes.filter(n => n.channel === "LongFast");
+filteredNodes = nodes.filter(n => n.channel === defaultChannel);
 dropdown.addEventListener('change', () => {
     const val = dropdown.value;
     filteredNodes = nodes.filter(n => n.channel === val);

--- a/sample.config.ini
+++ b/sample.config.ini
@@ -34,6 +34,10 @@ message = Real time data from around the bay area and beyond.
 # Starting URL when loading the index page.
 starting = /chat
 
+# Default channel used for pages that show a channel dropdown (e.g. Top, Nodegraph)
+# Set to the preferred channel name; if unset, the UI falls back to "LongFast".
+default_channel = LongFast
+
 # Enable or disable site features (as strings: "True" or "False").
 nodes = True
 conversations = True
@@ -64,17 +68,17 @@ net_tag = #BayMeshNet
 # -------------------------
 [mqtt]
 # MQTT server hostname or IP.
-server = mqtt.bayme.sh
+server = mqtt.meshhessen.de
 
 # Topics to subscribe to (as JSON-like list, but still a string).
-topics = ["msh/US/bayarea/#", "msh/US/CA/mrymesh/#", "msh/US/CA/sacvalley"]
+topics = ["msh/EU_868/#"]
 
 # Port used by MQTT (typically 1883 for unencrypted).
 port = 1883
 
 # MQTT username and password.
-username = meshdev
-password = large4cats
+username = Leo77-meshview
+password = Hf!59&tjS4
 
 
 # -------------------------

--- a/startdb.py
+++ b/startdb.py
@@ -169,4 +169,15 @@ async def main():
 # Entry point
 # -------------------------
 if __name__ == '__main__':
+    # On Windows, some asyncio operations (add_reader/add_writer) are not
+    # implemented on the default ProactorEventLoop; switch to the
+    # SelectorEventLoopPolicy which supports these functions.
+    try:
+        import sys
+        if sys.platform.startswith('win'):
+            import asyncio as _asyncio
+            _asyncio.set_event_loop_policy(_asyncio.WindowsSelectorEventLoopPolicy())
+    except Exception:
+        pass
+
     asyncio.run(main())


### PR DESCRIPTION
Introduce a default channel setting from site configuration, allowing the UI to fall back to "LongFast" if not specified. Update dropdowns and filtering logic to utilize this default channel.