### PR TITLE
fix: don't overwrite Node.channel from MAP_REPORT_APP if already set

### DIFF
--- a/meshview/mqtt_store.py
+++ b/meshview/mqtt_store.py
@@ -109,7 +109,8 @@ async def process_envelope(topic, env):
                     node.short_name = map_report.short_name
                     node.hw_model = hw_model
                     node.role = role
-                    node.channel = env.channel_id
+                    if not node.channel:
+                        node.channel = env.channel_id
                     node.last_lat = map_report.latitude_i
                     node.last_long = map_report.longitude_i
                     node.firmware = map_report.firmware_version


### PR DESCRIPTION
NODEINFO_APP is the better / authoritative source for a nodes primary channel. MAP_REPORT_APP packets can arrive on a different MQTT uplink channel and are unconditionally overwriting the channel set by NODEINFO, causing nodes to appear on the wrong channel in the map and channel filters.

now MAP_REPORT_APP only sets Node.channel when it is not (yetw) known, making it a fallback rather than an override.

There is a Bug: nodes appear on the wrong channel on the map
this is caused by:  Node.channel is written by two different packet handlers in mqtt_store.py, and whichever arrives last wins.

- NODEINFO_APP sets node.channel to the node's actual primary channel (e.g. "LongFast" "ShortSlow")
- MAP_REPORT_APP also sets node.channel -  but to the channel the MQTT gateway used for its **uplink report**, which can be totally different
 -> Because MQTT packets arrive in random order, a MAP_REPORT can overwrite a correctly set NODEINFO channel at any time, making nodes flip to the wrong channel.

(The map uses node.channel directly for both dot color and channel filter visibility, so the effect is sometimes immediately visible.)

the Fix: in the MAP_REPORT_APP handler in mqtt_store.py:112 -  only set the channel if it's not already known


## before
node.channel = env.channel_id

## after
if not node.channel:
    node.channel = env.channel_id
