### PR TITLE
fix: show ROUTING ACK/NAK instead of misleading "error_reason: NONE"

### DIFF
--- a/meshview/web.py
+++ b/meshview/web.py
@@ -16,6 +16,7 @@ from google.protobuf.message import Message
 from jinja2 import Environment, PackageLoader, Undefined, select_autoescape
 from markupsafe import Markup
 
+from meshtastic.protobuf.mesh_pb2 import Routing
 from meshtastic.protobuf.portnums_pb2 import PortNum
 from meshview import config, database, decode_payload, migrations, models, store
 from meshview.__version__ import (
@@ -81,6 +82,17 @@ class Packet:
 
         if payload is None:
             text_payload = "Did not decode"
+        elif (
+            packet.portnum == PortNum.ROUTING_APP
+            and isinstance(payload, Routing)
+            and payload.WhichOneof("variant") == "error_reason"
+        ):
+            # error_reason NONE is the implicit ACK, not a failure.
+            text_payload = (
+                "ACK"
+                if payload.error_reason == Routing.Error.NONE
+                else f"NAK: {Routing.Error.Name(payload.error_reason)}"
+            )
         elif isinstance(payload, Message):
             text_payload = text_format.MessageToString(payload)
         elif packet.portnum == PortNum.TEXT_MESSAGE_APP and packet.to_node_id != 0xFFFFFFFF:


### PR DESCRIPTION
Fixes #159

## Problem

Successful `ROUTING_APP` (portnum 5) acknowledgements render in the UI as
`error_reason: NONE`. That reads as an error in the firehose, packet list, and node
detail pages, when it is actually the opposite — it is the implicit ACK. Routing is one
of the highest-volume packet types on a busy mesh, so the packet list ends up looking
like it is full of errors.

<img width="238" height="313" alt="image" src="https://github.com/user-attachments/assets/34ee379f-0fe6-4bd9-87b4-f747823e8f64" />

## Root cause

`Packet.from_model()` in `meshview/web.py` renders decoded protobufs through the generic
`text_format.MessageToString(payload)` branch. For `Routing`, `error_reason` lives inside
a `oneof` (`variant`), so it has *explicit presence*: the zero value `NONE` is still
written to the wire and still reported as set by `WhichOneof()`. `MessageToString()`
therefore prints it verbatim instead of omitting it like a normal scalar zero.

## Fix

Special-case the `error_reason` variant of `Routing` before the generic branch:

- `error_reason == NONE` → `ACK`
- anything else → `NAK: <REASON>` (e.g. `NAK: NO_RESPONSE`)

Genuine failures stay visible and distinguishable. `route_request` / `route_reply` keep
their existing rendering, since the new branch only fires when
`WhichOneof("variant") == "error_reason"`.

## Verification

Captured 41 live `ROUTING_APP` packets from `mqtt.meshtastic.org` (`msh/EU_868/#`) and
replayed them through `Packet.from_model()`:

| error_reason | count | before | after |
| --- | --- | --- | --- |
| `NONE` | 19 | `error_reason: NONE` | `ACK` |
| `NO_RESPONSE` | 22 | `error_reason: NO_RESPONSE` | `NAK: NO_RESPONSE` |

All 41 had `request_id` set, confirming they are responses rather than route-discovery
requests. Also confirmed all 18 `Routing.Error` values render as expected,
`route_request` / `route_reply` and other portnums are unchanged, and `ruff check` /
`ruff format` pass.

## Scope

Presentation only — 12 added lines in `meshview/web.py`. No model, decoding, API-shape,
or migration changes. Branched off `3.0.8`.