### PR TITLE
fix: expand Meshtastic one-byte PSK shorthand in mqtt.secondary_keys

### DIFF
--- a/meshview/mqtt_reader.py
+++ b/meshview/mqtt_reader.py
@@ -12,7 +12,10 @@ from meshtastic.protobuf.mesh_pb2 import Data
 from meshtastic.protobuf.mqtt_pb2 import ServiceEnvelope
 from meshview.config import CONFIG
 
-PRIMARY_KEY = base64.b64decode("1PG7OiApB1nwvP+rz05pAQ==")
+# Meshtastic's well-known default PSK, i.e. the expansion of the single byte PSK index 1.
+DEFAULT_PSK = base64.b64decode("1PG7OiApB1nwvP+rz05pAQ==")
+PRIMARY_KEY = DEFAULT_PSK
+VALID_KEY_LENGTHS = (16, 32)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -52,6 +55,10 @@ def _strip_quotes(value):
     return value
 
 
+def _expand_short_psk(index):
+    return DEFAULT_PSK[:-1] + bytes([(DEFAULT_PSK[-1] + index - 1) % 256])
+
+
 def _parse_secondary_keys():
     mqtt_config = CONFIG.get("mqtt", {})
     raw_value = mqtt_config.get("secondary_keys", "")
@@ -68,12 +75,33 @@ def _parse_secondary_keys():
 
     keys = []
     for value in values:
+        cleaned = _strip_quotes(str(value).strip())
+        if not cleaned:
+            continue
+
         try:
-            cleaned = _strip_quotes(str(value).strip())
-            if cleaned:
-                keys.append(base64.b64decode(cleaned))
+            key = base64.b64decode(cleaned)
         except (TypeError, ValueError):
             logger.warning("Invalid base64 key in mqtt.secondary_keys: %s", value)
+            continue
+
+        if len(key) == 1:
+            if key[0] == 0:
+                logger.warning(
+                    "Skipping PSK %s in mqtt.secondary_keys: index 0 means no encryption", value
+                )
+                continue
+            key = _expand_short_psk(key[0])
+
+        if len(key) not in VALID_KEY_LENGTHS:
+            logger.error(
+                "Skipping key %s in mqtt.secondary_keys: decoded to %d bytes, expected 16 or 32",
+                value,
+                len(key),
+            )
+            continue
+
+        keys.append(key)
     return keys
 
 


### PR DESCRIPTION
Fixes #157

## Problem

Meshtastic stores well-known channel PSKs as a single byte index, so a channel
configured with the PSK `Ag==` could not be read by Meshview:

```ini
[mqtt]
secondary_keys = Ag==
```

That value was base64-decoded to a single byte (`0x02`) and handed straight to AES as
the key. Only the expanded form `1PG7OiApB1nwvP+rz05pAg==` worked.

The behaviour was also inconsistent: the default shorthand PSK `AQ==` works implicitly,
because Meshview hardcodes its expanded key as `PRIMARY_KEY`, while every other
shorthand PSK fails through `secondary_keys`.

It is worse than a silent decode failure, too. `algorithms.AES()` raises
`ValueError: Invalid key size (8) for AES` on a one-byte key, and the loop in
`get_topic_envelopes` only catches `aiomqtt.MqttError` — so the exception propagates and
kills the reader on the first packet it tries to decrypt.

## Fix

Expand single-byte PSKs the way the firmware does in `Channels::getKey`
(`src/mesh/Channels.cpp`): copy the default PSK and bump its *last* byte by
`index - 1`, so index 1 is the default PSK itself. Index 0 means "no encryption" and is
skipped with a warning.

Decoded keys are then validated to be 16 or 32 bytes; anything else is skipped with an
error naming the offending config value, so a bad key can no longer reach AES.

`PRIMARY_KEY` is now defined as `DEFAULT_PSK` — same bytes as before, just no longer a
magic literal that duplicates what the expansion produces.

## Verification

- `AQ==` -> `1PG7OiApB1nwvP+rz05pAQ==` and `Ag==` -> `1PG7OiApB1nwvP+rz05pAg==`, matching
  the issue. All 255 indices produce a 16-byte key differing only in the last byte.
- Config parsing covered for: shorthand, already-expanded keys, quoted values,
  comma-separated lists, AES-256 keys, index 0, too short, too long, and non-base64.
  `Ag==` and `1PG7OiApB1nwvP+rz05pAg==` parse to the same key.
- End to end: encrypted a `Data` protobuf with the `Ag==` channel key and confirmed it
  decrypts through `decrypt()` with the resulting keyring, and that the primary key alone
  does not decode it.
- Invalid config values no longer reach AES, so the reader no longer dies on them.
- `ruff check` and `ruff format` pass.

## Notes

Valid lengths are restricted to 16 and 32, which is what Meshtastic uses. `cryptography`
would also accept 24 (AES-192), but Meshtastic never generates such a PSK.

Branched off `3.0.8`.