### PR TITLE
fix: correct traceroute path orientation when building graph edges

### DIFF
--- a/docs/API_Documentation.md
+++ b/docs/API_Documentation.md
@@ -204,8 +204,10 @@ Traceroute edges are collected over the last 12 hours. Neighbor edges are based 
 port 71 packets.
 
 A completed traceroute is observed as a response packet, whose `from`/`to` are reversed
-with respect to the traced path, so edges are built as `to -> route[] -> from`. Unknown
-hop placeholders (`0xFFFFFFFF`) are skipped.
+with respect to the traced path, so edges are built as `to -> route[] -> from`. `route[]`
+may contain `0xFFFFFFFF` placeholders for hops the mesh could not identify; the edges on
+either side of such a placeholder are omitted, because the nodes around an unknown hop
+are not neighbours.
 
 Query Parameters
 - `type` (optional, string): `traceroute` or `neighbor`. If omitted, returns both.
@@ -334,6 +336,11 @@ runs `initiator -> forward_hops -> target` and the return path runs
 `target -> reverse_hops -> initiator`, in both directions of travel. `forward_hops` and
 `reverse_hops` contain only the intermediate hops, never the endpoints.
 
+A gateway usually reports a response that is still travelling home, so `reverse_hops` is
+often incomplete. `reverse_complete` says whether that observation had reached the
+initiator; only then does the corresponding `winning_paths.reverse` entry end at the
+initiator.
+
 Response Example
 ```json
 {
@@ -351,7 +358,8 @@ Response Example
       "gateway_node_id": 333,
       "done": true,
       "forward_hops": [444, 555],
-      "reverse_hops": [555, 444]
+      "reverse_hops": [555, 444],
+      "reverse_complete": true
     }
   ],
   "unique_forward_paths": [

--- a/docs/API_Documentation.md
+++ b/docs/API_Documentation.md
@@ -341,6 +341,10 @@ often incomplete. `reverse_complete` says whether that observation had reached t
 initiator; only then does the corresponding `winning_paths.reverse` entry end at the
 initiator.
 
+`winning_paths` is built from response observations, since a response proves the request
+reached the target. `complete` on a `unique_forward_paths` entry says whether some
+response reported that hop list, and so whether it is known to end at the target.
+
 Response Example
 ```json
 {
@@ -363,7 +367,7 @@ Response Example
     }
   ],
   "unique_forward_paths": [
-    { "path": [444, 555], "count": 2 }
+    { "path": [444, 555], "count": 2, "complete": true }
   ],
   "unique_reverse_paths": [
     [555, 444]

--- a/docs/API_Documentation.md
+++ b/docs/API_Documentation.md
@@ -203,6 +203,10 @@ Returns network edges (connections between nodes) based on traceroutes and neigh
 Traceroute edges are collected over the last 12 hours. Neighbor edges are based on
 port 71 packets.
 
+A completed traceroute is observed as a response packet, whose `from`/`to` are reversed
+with respect to the traced path, so edges are built as `to -> route[] -> from`. Unknown
+hop placeholders (`0xFFFFFFFF`) are skipped.
+
 Query Parameters
 - `type` (optional, string): `traceroute` or `neighbor`. If omitted, returns both.
 - `node_id` (optional, int): Filter edges to only those touching a node.
@@ -324,13 +328,21 @@ Returns traceroute details and derived paths for a packet.
 Path Parameters
 - `packet_id` (required, int): Packet ID.
 
+A completed traceroute is observed as a response packet, whose `from`/`to` are reversed
+with respect to the traced path. `initiator` and `target` resolve this: the forward path
+runs `initiator -> forward_hops -> target` and the return path runs
+`target -> reverse_hops -> initiator`, in both directions of travel. `forward_hops` and
+`reverse_hops` contain only the intermediate hops, never the endpoints.
+
 Response Example
 ```json
 {
   "packet": {
     "id": 123,
-    "from": 111,
-    "to": 222,
+    "from": 222,
+    "to": 111,
+    "initiator": 111,
+    "target": 222,
     "channel": "main"
   },
   "traceroute_packets": [
@@ -338,19 +350,20 @@ Response Example
       "index": 0,
       "gateway_node_id": 333,
       "done": true,
-      "forward_hops": [111, 444, 222],
-      "reverse_hops": [222, 444, 111]
+      "forward_hops": [444, 555],
+      "reverse_hops": [555, 444]
     }
   ],
   "unique_forward_paths": [
-    { "path": [111, 444, 222], "count": 2 }
+    { "path": [444, 555], "count": 2 }
   ],
   "unique_reverse_paths": [
-    [222, 444, 111]
+    [555, 444]
   ],
-  "winning_paths": [
-    [111, 444, 222]
-  ]
+  "winning_paths": {
+    "forward": [[111, 444, 555, 222]],
+    "reverse": [[222, 555, 444, 111]]
+  }
 }
 ```
 

--- a/meshview/templates/traceroute.html
+++ b/meshview/templates/traceroute.html
@@ -121,11 +121,11 @@ function addMissingEndpoints(path, startId, endId) {
     return fullPath;
 }
 
-// These lists are deduplicated across observations, so we cannot tell which of them
-// reached the far endpoint. Only the adjacent endpoint is safe to add.
+// These lists are deduplicated across observations. A forward path is only known to
+// reach the target if some response reported it; a reverse path carries no such marker.
 function uniqueForwardPaths(data, originId, targetId) {
     return (data?.unique_forward_paths || [])
-        .map(item => addMissingEndpoints(item.path || [], originId, null))
+        .map(item => addMissingEndpoints(item.path || [], originId, item.complete ? targetId : null))
         .filter(path => path.length > 1);
 }
 

--- a/meshview/templates/traceroute.html
+++ b/meshview/templates/traceroute.html
@@ -121,15 +121,17 @@ function addMissingEndpoints(path, startId, endId) {
     return fullPath;
 }
 
+// These lists are deduplicated across observations, so we cannot tell which of them
+// reached the far endpoint. Only the adjacent endpoint is safe to add.
 function uniqueForwardPaths(data, originId, targetId) {
     return (data?.unique_forward_paths || [])
-        .map(item => addMissingEndpoints(item.path || [], originId, targetId))
+        .map(item => addMissingEndpoints(item.path || [], originId, null))
         .filter(path => path.length > 1);
 }
 
 function uniqueReversePaths(data, originId, targetId) {
     return (data?.unique_reverse_paths || [])
-        .map(path => addMissingEndpoints(path || [], targetId, originId))
+        .map(path => addMissingEndpoints(path || [], targetId, null))
         .filter(path => path.length > 1);
 }
 

--- a/meshview/templates/traceroute.html
+++ b/meshview/templates/traceroute.html
@@ -129,7 +129,7 @@ function uniqueForwardPaths(data, originId, targetId) {
 
 function uniqueReversePaths(data, originId, targetId) {
     return (data?.unique_reverse_paths || [])
-        .map(path => addMissingEndpoints(path || [], targetId, null))
+        .map(path => addMissingEndpoints(path || [], targetId, originId))
         .filter(path => path.length > 1);
 }
 
@@ -157,8 +157,9 @@ async function loadTraceroute() {
     const nodes = new Map();
     const edges = [];
 
-    const originId = data?.packet?.from != null ? String(data.packet.from) : null;
-    const targetId = data?.packet?.to != null ? String(data.packet.to) : null;
+    // A response packet carries from/to reversed, so use the endpoints the API resolved.
+    const originId = data?.packet?.initiator != null ? String(data.packet.initiator) : null;
+    const targetId = data?.packet?.target != null ? String(data.packet.target) : null;
     const forwardPaths = (data?.winning_paths?.forward || []).map(path => path.map(id => String(id)));
     const reversePaths = (data?.winning_paths?.reverse || []).map(path => path.map(id => String(id)));
     const winningPathKeys = new Set([

--- a/meshview/traceroute.py
+++ b/meshview/traceroute.py
@@ -1,0 +1,38 @@
+"""Assemble node paths from Meshtastic RouteDiscovery payloads.
+
+A traceroute response carries the endpoints reversed with respect to the path
+being traced: `to` is the node that started the traceroute and `from` is the node
+that answered. Only the response direction is affected, so both orientations are
+handled here rather than at each call site.
+"""
+
+# Firmware inserts this into route[] as a placeholder for a hop it could not identify.
+NODENUM_BROADCAST = 0xFFFFFFFF
+
+
+def strip_unknown_hops(hops):
+    return [hop for hop in hops if hop != NODENUM_BROADCAST]
+
+
+def forward_path(from_node_id, to_node_id, hops, done, gateway_node_id=None):
+    """Path towards the traced node, starting at the node that began the traceroute."""
+    if done:
+        return [node for node in (to_node_id, *hops, from_node_id) if node is not None]
+
+    path = [node for node in (from_node_id, *hops) if node is not None]
+    # Some nodes add themselves to the route before uplinking.
+    if gateway_node_id is not None and (not path or path[-1] != gateway_node_id):
+        path.append(gateway_node_id)
+    return path
+
+
+def return_path(from_node_id, to_node_id, hops):
+    """Path back from the traced node, starting at the node that answered."""
+    return [node for node in (from_node_id, *hops, to_node_id) if node is not None]
+
+
+def endpoints(from_node_id, to_node_id, done):
+    """The (initiator, target) of the traceroute, regardless of packet direction."""
+    if done:
+        return to_node_id, from_node_id
+    return from_node_id, to_node_id

--- a/meshview/traceroute.py
+++ b/meshview/traceroute.py
@@ -10,8 +10,14 @@ handled here rather than at each call site.
 NODENUM_BROADCAST = 0xFFFFFFFF
 
 
-def strip_unknown_hops(hops):
-    return [hop for hop in hops if hop != NODENUM_BROADCAST]
+def return_is_complete(route):
+    """True when the response was seen after it reached the node that started it.
+
+    Relays append both their ID and their SNR, but the final recipient appends only its
+    SNR, so one spare SNR entry means the return trip finished. Gateways usually report
+    a response that is still in flight, where the remaining hops are not known yet.
+    """
+    return len(route.snr_back) == len(route.route_back) + 1
 
 
 def forward_path(from_node_id, to_node_id, hops, done, gateway_node_id=None):
@@ -26,9 +32,20 @@ def forward_path(from_node_id, to_node_id, hops, done, gateway_node_id=None):
     return path
 
 
-def return_path(from_node_id, to_node_id, hops):
+def return_path(from_node_id, to_node_id, hops, complete):
     """Path back from the traced node, starting at the node that answered."""
-    return [node for node in (from_node_id, *hops, to_node_id) if node is not None]
+    path = [node for node in (from_node_id, *hops) if node is not None]
+    if complete and to_node_id is not None:
+        path.append(to_node_id)
+    return path
+
+
+def edges(path):
+    """Consecutive pairs of a path, skipping links that run through an unknown hop."""
+    for a, b in zip(path, path[1:], strict=False):
+        if NODENUM_BROADCAST in (a, b):
+            continue
+        yield a, b
 
 
 def endpoints(from_node_id, to_node_id, done):

--- a/meshview/web.py
+++ b/meshview/web.py
@@ -17,7 +17,7 @@ from jinja2 import Environment, PackageLoader, Undefined, select_autoescape
 from markupsafe import Markup
 
 from meshtastic.protobuf.portnums_pb2 import PortNum
-from meshview import config, database, decode_payload, migrations, models, store
+from meshview import config, database, decode_payload, migrations, models, store, traceroute
 from meshview.__version__ import (
     __version_string__,
 )
@@ -395,14 +395,17 @@ async def graph_traceroute(request):
         route = decode_payload.decode_payload(PortNum.TRACEROUTE_APP, tr.route)
         if route is None:
             continue
-        path = [packet.from_node_id]
-        path.extend(route.route)
+        path = traceroute.forward_path(
+            packet.from_node_id,
+            packet.to_node_id,
+            route.route,
+            tr.done,
+            tr.gateway_node_id,
+        )
+        if not path:
+            continue
         if tr.done:
-            dest = packet.to_node_id
-            path.append(packet.to_node_id)
-        elif path[-1] != tr.gateway_node_id:
-            # It seems some nodes add them self to the list before uplinking
-            path.append(tr.gateway_node_id)
+            dest = path[-1]
 
         if not tr.done and tr.gateway_node_id not in node_seen_time and tr.import_time_us:
             node_seen_time[path[-1]] = tr.import_time_us

--- a/meshview/web_api/api.py
+++ b/meshview/web_api/api.py
@@ -10,7 +10,7 @@ from aiohttp import web
 from sqlalchemy import func, select
 
 from meshtastic.protobuf.portnums_pb2 import PortNum
-from meshview import database, decode_payload, store
+from meshview import database, decode_payload, store, traceroute
 from meshview.__version__ import __version__, _git_revision_short, get_version_info
 from meshview.config import CONFIG
 from meshview.models import DailySnapshot, Node
@@ -630,8 +630,13 @@ async def api_edges(request):
             if route is None or tr.packet is None:
                 continue
 
-            path = [tr.packet.from_node_id] + list(route.route)
-            path.append(tr.packet.to_node_id if tr.done else tr.gateway_node_id)
+            path = traceroute.forward_path(
+                tr.packet.from_node_id,
+                tr.packet.to_node_id,
+                traceroute.strip_unknown_hops(route.route),
+                tr.done,
+                tr.gateway_node_id,
+            )
 
             for a, b in zip(path, path[1:], strict=False):
                 if (a, b) not in edges:
@@ -989,21 +994,16 @@ async def api_traceroute(request):
 
     from_node_id = packet.from_node_id
     to_node_id = packet.to_node_id
-    winning_forward_with_endpoints = []
-    for path in set(winning_forward_paths):
-        full_path = list(path)
-        if to_node_id is not None and (not full_path or full_path[-1] != to_node_id):
-            full_path = [to_node_id, *full_path]
-        if from_node_id is not None and (not full_path or full_path[-1] != from_node_id):
-            full_path = [*full_path, from_node_id]
-        winning_forward_with_endpoints.append(full_path)
+    # Winning paths are only built from responses, which carry the endpoints reversed.
+    winning_forward_with_endpoints = [
+        traceroute.forward_path(from_node_id, to_node_id, path, done=True)
+        for path in set(winning_forward_paths)
+    ]
 
-    winning_reverse_with_endpoints = []
-    for path in set(winning_reverse_paths):
-        full_path = list(path)
-        if to_node_id is not None and (not full_path or full_path[0] != to_node_id):
-            full_path = [to_node_id, *full_path]
-        winning_reverse_with_endpoints.append(full_path)
+    winning_reverse_with_endpoints = [
+        traceroute.return_path(from_node_id, to_node_id, path)
+        for path in set(winning_reverse_paths)
+    ]
 
     winning_paths_json = {
         "forward": winning_forward_with_endpoints,
@@ -1013,12 +1013,17 @@ async def api_traceroute(request):
     # --------------------------------------------
     # Final API output
     # --------------------------------------------
+    initiator, target = traceroute.endpoints(
+        from_node_id, to_node_id, any(tr["done"] for tr in tr_groups)
+    )
     return web.json_response(
         {
             "packet": {
                 "id": packet.id,
                 "from": packet.from_node_id,
                 "to": packet.to_node_id,
+                "initiator": initiator,
+                "target": target,
                 "channel": packet.channel,
             },
             "traceroute_packets": tr_groups,

--- a/meshview/web_api/api.py
+++ b/meshview/web_api/api.py
@@ -961,6 +961,7 @@ async def api_traceroute(request):
 
     forward_paths = []
     reverse_paths = []
+    forward_complete = set()
     winning_forward_paths = []
     winning_reverse_paths = []
 
@@ -974,9 +975,10 @@ async def api_traceroute(request):
         if tr["reverse_hops"]:
             reverse_paths.append(r)
 
-        if tr["reverse_hops"]:
-            if tr["forward_hops"]:
-                winning_forward_paths.append(f)
+        # A response proves the request reached the target, whatever its return trip did.
+        if tr["done"]:
+            forward_complete.add(f)
+            winning_forward_paths.append(f)
             winning_reverse_paths.append((r, tr["reverse_complete"]))
 
     # Deduplicate
@@ -988,7 +990,8 @@ async def api_traceroute(request):
 
     # Convert for JSON output
     unique_forward_paths_json = [
-        {"path": list(p), "count": forward_counts[p]} for p in unique_forward_paths
+        {"path": list(p), "count": forward_counts[p], "complete": p in forward_complete}
+        for p in unique_forward_paths
     ]
 
     unique_reverse_paths_json = [list(p) for p in unique_reverse_paths]
@@ -996,15 +999,16 @@ async def api_traceroute(request):
     from_node_id = packet.from_node_id
     to_node_id = packet.to_node_id
     # Winning paths are only built from responses, which carry the endpoints reversed.
-    winning_forward_with_endpoints = [
-        traceroute.forward_path(from_node_id, to_node_id, path, done=True)
-        for path in set(winning_forward_paths)
-    ]
+    winning_forward_with_endpoints = []
+    for hops in dict.fromkeys(winning_forward_paths):
+        path = traceroute.forward_path(from_node_id, to_node_id, hops, done=True)
+        if len(path) > 1:
+            winning_forward_with_endpoints.append(path)
 
     winning_reverse_with_endpoints = []
     for hops, complete in winning_reverse_paths:
         path = traceroute.return_path(from_node_id, to_node_id, hops, complete)
-        if path not in winning_reverse_with_endpoints:
+        if len(path) > 1 and path not in winning_reverse_with_endpoints:
             winning_reverse_with_endpoints.append(path)
 
     winning_paths_json = {

--- a/meshview/web_api/api.py
+++ b/meshview/web_api/api.py
@@ -633,12 +633,12 @@ async def api_edges(request):
             path = traceroute.forward_path(
                 tr.packet.from_node_id,
                 tr.packet.to_node_id,
-                traceroute.strip_unknown_hops(route.route),
+                route.route,
                 tr.done,
                 tr.gateway_node_id,
             )
 
-            for a, b in zip(path, path[1:], strict=False):
+            for a, b in traceroute.edges(path):
                 if (a, b) not in edges:
                     edges[(a, b)] = "traceroute"
                     edges_added_tr += 1
@@ -950,6 +950,7 @@ async def api_traceroute(request):
                 "done": tr.done,
                 "forward_hops": forward_list,
                 "reverse_hops": reverse_list,
+                "reverse_complete": traceroute.return_is_complete(route),
             }
         )
 
@@ -976,7 +977,7 @@ async def api_traceroute(request):
         if tr["reverse_hops"]:
             if tr["forward_hops"]:
                 winning_forward_paths.append(f)
-            winning_reverse_paths.append(r)
+            winning_reverse_paths.append((r, tr["reverse_complete"]))
 
     # Deduplicate
     unique_forward_paths = sorted(set(forward_paths))
@@ -1000,10 +1001,11 @@ async def api_traceroute(request):
         for path in set(winning_forward_paths)
     ]
 
-    winning_reverse_with_endpoints = [
-        traceroute.return_path(from_node_id, to_node_id, path)
-        for path in set(winning_reverse_paths)
-    ]
+    winning_reverse_with_endpoints = []
+    for hops, complete in winning_reverse_paths:
+        path = traceroute.return_path(from_node_id, to_node_id, hops, complete)
+        if path not in winning_reverse_with_endpoints:
+            winning_reverse_with_endpoints.append(path)
 
     winning_paths_json = {
         "forward": winning_forward_with_endpoints,


### PR DESCRIPTION
Fixes #158

## Problem

Meshview builds graph edges from completed traceroutes using the packet endpoints in the
wrong order:

```python
path = [tr.packet.from_node_id] + list(route.route)
path.append(tr.packet.to_node_id if tr.done else tr.gateway_node_id)
```

For a completed traceroute (`done == True`), `tr.packet` is the *response*, whose
`from`/`to` are reversed with respect to the traced path. A real path
`Alpha > Bravo > Charlie > Delta` came out as `Delta > Bravo > Charlie > Alpha`:
`Bravo—Charlie` correct, both endpoint-adjacent edges wrong. Since the false edges always
attach to the endpoints, a busy initiator or gateway accumulates false direct links to
every remote target it ever traced, while the real endpoint edges go missing.

## Why this orientation

`TraceRouteModule::alterReceivedProtobuf` in meshtastic/firmware:
```cpp
if (!incoming.request_id) printRoute(r, p.from, p.to, true);   // request
else                      printRoute(r, p.to,   p.from, false); // response
```
`MeshInterface.onResponseTraceRoute` in meshtastic/python starts the forward path at
`p["to"]` ("destination of response") and ends it at `p["from"]`.

So for a response: forward is `to -> route[] -> from`, return is `from -> route_back[] -> to`.
`done` reliably identifies responses — `mqtt_store` sets `done = not want_response`, and
only requests set `want_response`.

## What changed

Four places had independently drifting copies of this logic:

| Site | Before |
|---|---|
| `/api/edges` | `[from, *route, to]` — wrong |
| `graph_traceroute` | `[from, *route, to]` — wrong; also styled the initiator as the destination |
| `/api/traceroute` winning **reverse** | `[to, *route_back]` — wrong start, missing end |
| `traceroute.html` | re-derived endpoints from `packet.from`/`to` — wrong |

(The winning **forward** path was already fixed on `3.0.8`.)

New `meshview/traceroute.py` holds the path logic once, used from all three Python sites.
`/api/traceroute` also returns `initiator` and `target` so the page stops re-deriving
endpoints in JS.

### Only assert links that were actually observed

Getting the endpoints right is not enough on its own — two other cases would still put
links in the graph that nobody saw:

- **Unknown hops.** `insertUnknownHops()` writes `0xFFFFFFFF` into `route[]`. Treating it
  as a node makes it a pseudo-node hub in the graph; simply dropping it is worse, since
  that joins the nodes either side (`A > B > ? > C > D` becomes a claimed `B—C`, and a
  lone unknown hop becomes a false direct `A—D`). The placeholder stays in the path and
  the edges touching it are skipped instead. On a 2660 row sample that is 10 links kept
  out of the graph.
- **Unfinished returns.** `done == True` means a response was *observed*, not that it
  arrived — gateways usually see one still travelling home, with `route_back` holding
  only the hops so far. The initiator is appended only when the response reached it,
  marked by the spare `snr_back` entry that the final recipient adds
  (`len(snr_back) == len(route_back) + 1`), exposed per observation as `reverse_complete`.

  > Worth knowing before merge: that signal is rare here — **2 of 303** real responses,
  > because it is added by the initiator and gateways see packets in flight. So most
  > return paths stop one hop short rather than closing on the initiator. That is the
  > honest rendering, but it is a visible change.

Also: `/api/edges` lacked `graph_traceroute`'s `(gateway, gateway)` self-edge guard; the
shared helper guards both. And since `unique_forward_paths`/`unique_reverse_paths` are
deduplicated across observations, the page cannot tell which reached the far endpoint, so
it adds only the adjacent one.

Winning paths are selected from response observations rather than from the presence of
return hops. A response only exists because the request arrived, so its forward path is
known-complete even before the first return hop is seen; keying off `route_back` instead
dropped the target from any response observed that early. Reported forward paths carry a
`complete` flag saying whether some response reported them, so the page knows which ones
may close on the target. A side effect is that a fully direct traceroute and a completed
direct return now appear in the graph — both were previously excluded for having no hops.

Deliberately left out: feeding `route_back` into `/api/edges` — a behaviour change, not a
bug fix.

## Screenshots

Both are `/traceroute/3866878993` on real data: `PiMM` (RasPi MeshMonitor) traced `🐝`
(Alameda High School), 7 hops out. The response carries `from = 🐝`, `to = PiMM`. Green is
the forward path, red dashed the return path.

**Before** — the return path is drawn `PiMM > VAL3`: it starts at the *initiator* and
dead-ends at VAL3, never involving `🐝`, the node that answered. The grey edges
`SBM7 > PiMM` and `🐝 > Mat` are the same mis-orientation on the non-winning overlay. PiMM
is a monitoring node that traces the whole mesh, so it is exactly the kind of node that
accumulates false links here.

<img width="2547" height="1505" alt="image" src="https://github.com/user-attachments/assets/1127390c-2c2b-4137-86c8-653374c6fff4" />

**After** — forward runs `PiMM > Mat > WIPh > PARs > BUTT > Smst > TOW > SBM7 > 🐝`; the
return starts at `🐝` and stops at `VAL3`, since both observations caught the response
still travelling home. The grey overlay edges are gone.

<img width="2547" height="1505" alt="image" src="https://github.com/user-attachments/assets/13c12aff-f5c7-408c-aab3-4bc7b44202b1" />

## Verification

A scratch script drives the real `/api/edges`, `/api/traceroute` and `/graph/traceroute`
handlers against SQLite built by feeding real `ServiceEnvelope` protobufs through
`mqtt_store.process_envelope` — nothing under test is mocked. Two gateways observe the
same response at different points on its way home:

```
api/edges: [('0xa','0xb'), ('0xb','0xc'), ('0xc','0xd')]
api/traceroute forward: ['0xa','0xb','0xc','0xd']
api/traceroute reverse: ['0xd','0xc']             <- in flight, stops short
api/traceroute reverse: ['0xd','0xc','0xb','0xa'] <- arrived, closes
```

Against `3.0.8` the same script reproduces the reported symptoms exactly, so it is not
vacuous:
```
[('0xa','0xb'), ('0xb','0xc'), ('0xb','0xffffffff'), ('0xc','0xa'),
 ('0xd','0xb'), ('0xffffffff','0x60')]
```

The orientation was validated against real recorded traceroutes from a public Meshview
deployment (1000 packets, ~300 completed responses), read only. Requests and responses
are told apart by `snr_back`, then tied together by `route[]` content: `route[]`
accumulates in initiator -> target order and is anchored at the request's `from`, so a
request whose `route[]` is a prefix of a response's identifies which endpoint that hop
list is anchored to.

```
request was  to -> from  (anchored at response.to)  : 15
request was  from -> to  (anchored at response.from): 0
both directions matched (inconclusive)              : 0
```

For example, response `3866878993` (`0x1774aa70 -> 0x9e7612c8`) carries the hop list of
request `3261317233` (`0x9e7612c8 -> 0x1774aa70`) continued, so it starts adjacent to
`0x9e7612c8` — the response's `to`. That is the packet in the screenshots. 296 of 303
responses also satisfy `len(snr_towards) == len(route) + 1`, confirming hops exclude the
endpoints.

`ruff format` and `ruff check` pass.

## Notes

- `initiator`, `target`, `reverse_complete` and `complete` are additive; nothing was
  removed or changed meaning.
- `docs/API_Documentation.md` updated; its `winning_paths` example was also stale from
  before `3.0.8` (documented as a list, actually an object).
- Branched off `3.0.8`.