### PR TITLE
fix: make non-preset channel colors visible on the map

### DIFF
--- a/meshview/templates/map.html
+++ b/meshview/templates/map.html
@@ -207,8 +207,11 @@ const UNMAPPED_TTL_MS = 5000;
 
 const portMap = window.PORT_LABEL_MAP;
 
-const palette = ["#bcf60c","#fabebe","#e6beff","#9a6324","#fffac8","#800000","#aaffc3","#ffd8b1",
-                 "#808080"];
+// Fallback colors for channels that are not Meshtastic presets.
+// Every entry clears 3:1 contrast against both the light map tiles and the dark
+// filter panel, and stays perceptually far from every channelColorOverrides value.
+const palette = ["#18aa18","#976049","#a5508c","#1898dc","#3a8846","#dc1884",
+                 "#b8813d","#b64f35","#408b18","#4c719e","#be379c","#18aa52"];
 
 const channelColorOverrides = {
     longfast: "#4363d8",


### PR DESCRIPTION
Fixes #163.

Channels that are not Meshtastic presets fall back to a palette of pastels that is unreadable against the light OSM tiles. Measuring WCAG contrast of the current fallback palette against the map background:

| color   | contrast vs map |
|---------|-----------------|
| #fffac8 | 1.06:1          |
| #aaffc3 | 1.18:1          |
| #bcf60c | 1.29:1          |
| #ffd8b1 | 1.34:1          |
| #fabebe | 1.59:1          |
| #e6beff | 1.59:1          |

Six of the nine entries score under 1.6:1, which is why the markers in #163 look like they have no fill at all — only the white outline is visible. Of the nine, only `#9a6324` and `#808080` were usable.

The underlying issue is that a single color feeds two opposite backgrounds: the marker fill sits on the light map tiles, while the channel filter label is text on the dark Bootstrap panel. The old palette was calibrated only for the panel, which is why every entry scores well there (9:1 to 14:1) and terribly on the map.

This replaces it with 12 colors chosen by a search over HSL space, constrained to:

- clear 3:1 contrast against **both** the light map and the dark filter panel
- stay at deltaE >= 30 from every `channelColorOverrides` preset, so a private channel is never mistaken for LongFast or MediumSlow
- stay at deltaE >= 20.9 from each other

Saturation is capped at 80% to keep out neon tones that would collide with ShortTurbo. The window that satisfies both backgrounds is narrow (relative luminance roughly 0.15-0.30), which is why the result is mid-saturation rather than pastel or near-black.

Four of the twelve are greenish. That is not an oversight: the presets already occupy blue, red, orange, purple, magenta, cyan, teal and olive, so green is the hue range left free — and it helps non-preset channels read as a distinct group.

Growing the palette from 9 to 12 entries is safe: the index is derived from `palette.length` rather than a fixed number.

One thing I deliberately left out of scope: the presets themselves have the inverse problem on the dark filter panel. `longslow` (#000075) scores 1.08:1 there and `longmoderate` (#46f0f0) scores 1.40:1 on the map, so LongSlow is close to illegible as a filter label. Fixing that properly means decoupling the two uses — a base color for the marker and a lightened variant for the panel text — rather than swapping hex values, so it felt like a separate change to make. Happy to follow up with it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
